### PR TITLE
Add styling for file input

### DIFF
--- a/src/Field/File.php
+++ b/src/Field/File.php
@@ -60,16 +60,32 @@ final class File extends AbstractField
         } else if (isset($this->mime_types[$this->options['type']])) {
             $this->options['mime_types'] = $this->mime_types[$this->options['type']];
         }
+
+        $this->options['button_text'] = $this->attributes['button_text'] ?? __('Select File');
+        $this->options['button_icon'] = $this->attributes['button_icon'] ?? null;
     }
 
     public function getField($form_name): ?string
     {
         list($attribute_string, $class) = $this->_attributeString();
 
-        return sprintf('<input type="file" name="%1$s" id="%2$s_%1$s" class="%3$s"/>',
+        $button_text = $this->options['button_text'];
+
+        if ($this->options['button_icon'] !== null) {
+            $button_text .= sprintf(' <i class="material-icons" aria-hidden="true">%1$s</i>', $this->options['button_icon']);
+        }
+
+        $output = '<button name="%1$s_button" id="%2$s_%1$s_button" class="file-upload btn btn-primary btn-block text-center %3$s" type="button">';
+        $output .= '%4$s';
+        $output .= '</button>';
+        $output .= '<small class="file-name"></small>';
+        $output .= '<input type="file" name="%1$s" id="%2$s_%1$s" style="visibility: hidden; position: absolute;">';
+
+        return sprintf($output,
             $this->getFullName(),
             $form_name,
-            $class
+            $class,
+            $button_text
         );
     }
 

--- a/src/Field/File.php
+++ b/src/Field/File.php
@@ -61,7 +61,7 @@ final class File extends AbstractField
             $this->options['mime_types'] = $this->mime_types[$this->options['type']];
         }
 
-        $this->options['button_text'] = $this->attributes['button_text'] ?? __('Select File');
+        $this->options['button_text'] = $this->attributes['button_text'] ?? 'Select File';
         $this->options['button_icon'] = $this->attributes['button_icon'] ?? null;
     }
 


### PR DESCRIPTION
The styled file input needs the following JS to work correctly:

```
$('form button.file-upload').on('click', function(e) {
    let inputElement = $(this).siblings('input[type=file]')[0];

    $(inputElement).trigger('click');
});

$('form input[type=file]').change(function (e){
    let fileNameElement = $(this).siblings('.file-name')[0];

    $(fileNameElement).text($(this).val().split('\\').pop());
});
```

It could make sense to add an `styled` or `unstyled` option to be able to show a file input without the JS. What do you think?